### PR TITLE
remove lights toplevel element to fix compatibility with Harmony Hub

### DIFF
--- a/alexa/alexa-home.js
+++ b/alexa/alexa-home.js
@@ -131,7 +131,7 @@ module.exports = function (RED) {
     AlexaHomeController.prototype.generateControllerConfig = function () {
         var keys = Object.keys(this._commands);
         var itemCount = keys.length;
-        var data = '{ "lights": { ';
+        var data = '{ ';
         for (var i = 0; i < itemCount; ++i) {
             var uuid = keys[i];
             data += '"' + uuid + '": ' + this.generateCommandConfig(uuid, this._commands[uuid]);
@@ -139,7 +139,7 @@ module.exports = function (RED) {
                 data += ","
             }
         }
-        data = data + " } }";
+        data = data + " }";
         return data;
     }
 


### PR DESCRIPTION
I tried to use the hue emulation of this node with Logitech Harmony Hub, but was not able to link the hub with the hue emulation.

Turned out that the `/lights` endpoint with the full list of lights is not understood by the Harmony Hub. But it works if the list of lights is not wrapped in the top-level `lights` object. The Hub just expects a map of Id to configuration. 

My Alexa device can still understand this node, event without `lights`.
I also cross-checked with [Openhab's hue emulation](https://github.com/openhab/openhab2-addons/blob/master/addons/io/org.openhab.io.hueemulation/src/main/java/org/openhab/io/hueemulation/internal/HueEmulationServlet.java) and they are also not sending a top-level `lights` object.