### PR TITLE
Updated some endpoints to conform to the Api v1 Specs

### DIFF
--- a/alexa/alexa-home-controller.js
+++ b/alexa/alexa-home-controller.js
@@ -218,7 +218,7 @@ module.exports = function(RED) {
     };
     const content = Mustache.render(template, data)
         .replace(/(\{\s+)?,?[^,]+_emptyIteratorStopper": \{\}/g, '$1');
-    RED.log.debug(node.name + + '/' + id +
+    RED.log.debug(node.name + '/' + id +
       ' - listing ' + request.params.username +
       ' #' + data.lights.length + ' api information to ' +
       request.connection.remoteAddress);

--- a/alexa/alexa-home.js
+++ b/alexa/alexa-home.js
@@ -9,7 +9,6 @@ module.exports = function(RED) {
    **/
   function AlexaHomeNode(config) {
     RED.nodes.createNode(this, config);
-
     const node = this;
     node.name = config.devicename;
     node.control = config.control;
@@ -23,6 +22,7 @@ module.exports = function(RED) {
     node.state = false;
     node.bri = alexaHome.bri_default;
     node.xy = [0, 0];
+    node.uniqueid = node.generateUniqueId(config.id);
 
     node.on('input', function(msg) {
       msg.inputTrigger = true;
@@ -143,6 +143,15 @@ module.exports = function(RED) {
     RED.log.debug(node.name + ' - sending values');
 
     node.send(msg);
+  };
+
+  AlexaHomeNode.prototype.generateUniqueId = function(uuid) {
+    let i = 9;
+    const base = '00:11:22:33:44:55:66:77-88';
+    const nodeid = uuid.split('');
+    const uniqueid = base.replace(/\d/g, () =>
+      nodeid.shift() || Math.max(--i, 0), 'g');
+    return uniqueid;
   };
 
   RED.nodes.registerType('alexa-home', AlexaHomeNode);

--- a/alexa/alexa-hub.js
+++ b/alexa/alexa-hub.js
@@ -16,6 +16,8 @@ function AlexaHub(controller, port, id) {
   node.id = id;
   node.port = port + id;
 
+  node.willClose = false;
+
   const protocol = 'http';
   const options = undefined;
   node.createServer(protocol, options);
@@ -57,6 +59,11 @@ AlexaHub.prototype.createServer = function(protocol, options) {
         req.url);
       if (Object.keys(req.body).length > 0) {
         node.controller.debug('Request body: ' + JSON.stringify(req.body));
+      }
+      if (node.willClose) {
+        res.set('Connection', 'close');
+        res.status(503).json({error: 'Temporarly Unavailable'});
+        return;
       }
       next();
     });
@@ -113,6 +120,7 @@ AlexaHub.prototype.createServer = function(protocol, options) {
 
 AlexaHub.prototype.stopServers = function() {
   const node = this;
+  node.willClose = true;
   node.controller.log('Stopping ssdp');
   node.ssdpServer.stop();
   node.controller.log('Stopping app');

--- a/alexa/alexa-hub.js
+++ b/alexa/alexa-hub.js
@@ -77,8 +77,16 @@ AlexaHub.prototype.createServer = function(protocol, options) {
       node.controller.handleApiCall(node.id, req, res);
     });
 
+    app.get('/api/config', function(req, res) {
+      node.controller.handleConfigList(node.id, req, res);
+    });
+
     app.get('/api/:username', function(req, res) {
       node.controller.handleApiCall(node.id, req, res);
+    });
+
+    app.get('/api/:username/config', function(req, res) {
+      node.controller.handleConfigList(node.id, req, res);
     });
 
     app.get('/api/:username/:itemType', function(req, res) {

--- a/alexa/templates/items/config.json
+++ b/alexa/templates/items/config.json
@@ -1,0 +1,39 @@
+{
+    "name": "Philips hue",
+    "zigbeechannel": 25,
+    "bridgeid": "{{ bridgeid }}",
+    "mac": "{{ macaddress }}",
+    "dhcp":true,
+    "apiversion": "1.10.0",
+    "swversion": "01028090",
+    "replacesbridgeid": null,
+    "factorynew": false,
+    {{#username}}
+    "ipaddress":"{{ address }}",
+    "netmask":"0.0.0.0",
+    "gateway":"0.0.0.0",
+    "proxyaddress":"none",
+    "proxyport":0,
+    "UTC":"{{ date }}",
+    "localtime": "none",
+    "timezone": "none",
+    "whitelist":{
+        "{{ username }}":{
+        "last use date":"{{ date }}",
+        "create date":"{{ date }}",
+        "name":"Echo"
+        }
+    },
+    "swversion":"01003372",
+    "swupdate":{
+        "updatestate":0,
+        "url":"",
+        "text":"",
+        "notify":false
+    },
+    "linkbutton":false,
+    "portalservices":false,
+    {{/username}}
+    "modelid": "BSB001",
+    "starterkitid": ""
+}

--- a/alexa/templates/items/list.json
+++ b/alexa/templates/items/list.json
@@ -27,7 +27,7 @@
         "manufacturername": "Philips",
         "productname": "Hue color lamp",
         "swversion": "5.105.0.21169",
-        "uniqueid":"00:11:22:33:44:55:66:77-88"
+        "uniqueid":"{{ uniqueid }}"
     },
   {{/lights}}
   "_emptyIteratorStopper": {}

--- a/alexa/templates/response.json
+++ b/alexa/templates/response.json
@@ -1,30 +1,6 @@
 {
    "lights": {{> itemsTemplate }},
-   "config":{
-      "name":"Philips hue",
-      "mac":"00:00:00:aa:bb:cc",
-      "dhcp":true,
-      "ipaddress":"{{ address }}",
-      "netmask":"0.0.0.0",
-      "gateway":"0.0.0.0",
-      "proxyaddress":"",
-      "proxyport":0,
-      "UTC":"{{ date }}",
-      "whitelist":{
-         "{{ username }}":{
-            "last use date":"{{ date }}",
-            "create date":"{{ date }}",
-            "name":"Echo"
-         }
-      },
-      "swversion":"01003372",
-      "swupdate":{
-         "updatestate":0,
-         "url":"",
-         "text":"",
-         "notify":false
-      },
-      "linkbutton":false,
-      "portalservices":false
-   }
+   "groups": {},
+   "config": {{> configTemplate }},
+   "schedules": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-alexa-home",
-  "version": "1.2.1",
+  "version": "1.4.3",
   "description": "Works directly with Alexa in your local network",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Hello,
I wanted my lights to be discovered by Home Assistant and after some investigation, I saw that some endpoints of the API does not conform to the Phillips Hue API v1  https://github.com/home-assistant-libs/aiohue/issues/57.

## 1. API v1 Specs

I added a `mac` address, and an`uniqueId` for the lights generated from the nodeID, and a `bridgeid` to the bridge config (used by Home Assistant to create the devices). It should be a good idea to add a settings to overwrite the node id to avoid reconfiguring all the lights in Alexa in case of a change in nodered nodes.

Now the endpoint `/api/config` return something like this:

```json
{
  "name": "Philips hue",
  "zigbeechannel": 25,
  "bridgeid": "020ED0FFFE1F52A1",
  "mac": "02:0E:D0:1F:52:A1",
  "dhcp": true,
  "apiversion": "1.10.0",
  "swversion": "01028090",
  "replacesbridgeid": null,
  "factorynew": false,
  "modelid": "BSB001",
  "starterkitid": ""
}
```

For the lights:

```json
" af8cd4e4f8051d8e": {
      "state": {
        "on": false,
        "bri": 254,
        "hue": 0,
        "sat": 254,
        "effect": "none",
        "xy": [
          0,
          0
        ],
        "ct": 199,
        "colormode": "ct",
        "reachable": true,
        "alert": "none",
        "mode": "homeautomation"
      },
      "swupdate": {
        "state": "noupdates",
        "lastinstall": "2022-02-18T10:31:24"
      },
      "type": "Extended color light",
      "name": "SmartLight",
      "modelid": "LCT007",
      "manufacturername": "Philips",
      "productname": "Hue color lamp",
      "swversion": "5.105.0.21169",
      "uniqueid": "af:8c:d4:e4:f8:05:1d:8e-87"
```

## 2. Server Timeout

I had a problem while reloading Node-RED, for a long period of time each time a request was received, the node will return that the lights does not exists. The consequence was that Home Assistant desactivated all the lights each time I reloaded Node-RED.

I could not reproduce the problem and I spend a lot of time trying to catch the problem. I discovered that when reloading, the hub was detached from the express server which will not close immediately (maybe due to active connections), and the express server continue to serve the requests and returns that there is no lights.

The workaround I found is to add a middleware to close the connection and return a different error code [here](https://github.com/atika/node-red-contrib-alexa-home/blob/c865a3ee3011abd755a1331d48c1c502d91f653b/alexa/alexa-hub.js#L63)

After added this, reloading Node-RED, reload this node almost immediatly.

